### PR TITLE
fix(deployment): populate spec.resources

### DIFF
--- a/charts/github-actions-runners/Chart.yaml
+++ b/charts/github-actions-runners/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1

--- a/charts/github-actions-runners/templates/deployment.yaml
+++ b/charts/github-actions-runners/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
We had support for passing `resources` via Helm values, but actual property of RunnerDeployment spec was not populated.